### PR TITLE
Added new input option to download_ncbi_assemblies

### DIFF
--- a/download_ncbi_assemblies.py
+++ b/download_ncbi_assemblies.py
@@ -57,7 +57,7 @@ def download_assembly(url, file_name):
     return response
 
 
-def main(input_table, ftp_path_list , output_directory):
+def main(input_table, ftp_path_list, output_directory):
 
     if not os.path.isdir(output_directory):
         os.mkdir(output_directory)


### PR DESCRIPTION
Added the a new input option to the [download_ncbi_assemblies.py](https://github.com/rfm-targa/Python_Bioinformatics_Miscellaneous_Scripts/blob/master/download_ncbi_assemblies.py) script.

This option allows the user to give as input a file containing a list of ftp paths (one per line), avoiding the hassle of downloading a Genome Assembly and Annotation report table. 
This new option will allow, for example,  the download of genomes from RefSeq.

Also added checks for the inputs.

